### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=SparkFun Electronics
 maintainer=SparkFun Electronics
 sentence=An Arduino library for interfacing with the BQ72441-G1 LiPo Fuel Gauge
 paragraph=An Arduino library for interfacing with the BQ72441-G1 LiPo Fuel Gauge
-category=sensors
+category=Sensors
 url=https://github.com/sparkfun/SparkFun_BQ27441_Arduino_Library
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'sensors' in library SparkFun BQ72441 LiPo Fuel Gauge Arduino Library is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format